### PR TITLE
Fixed Unlit and Matcap not falling back due to wrong shader name

### DIFF
--- a/XSFallbackTester/Editor/RenderFallbacks.cs
+++ b/XSFallbackTester/Editor/RenderFallbacks.cs
@@ -144,7 +144,7 @@ public class RenderFallbacks : EditorWindow
         }
         else
         {
-            r.sharedMaterials[j].shader = Shader.Find("Fallback/Fallback_Matcap");
+            r.sharedMaterials[j].shader = Shader.Find("Fallback/Matcap");
             r.sharedMaterials[j].SetColor("_MatcapColorTintHolyMolyDontReadThis", trustRankColor);
         }
         currentShader[i][j] = r.sharedMaterials[j].shader;

--- a/XSFallbackTester/Resources/FallbackShaders/Fallback_Matcap.shader
+++ b/XSFallbackTester/Resources/FallbackShaders/Fallback_Matcap.shader
@@ -1,7 +1,7 @@
-﻿Shader "Fallback/Fallback_Matcap"
+﻿Shader "Fallback/Matcap"
 {
 	Properties
-	{	
+	{
 		[HideInInspector]_MatcapTextureFallbackThisIsARediculousNameSoThatItDoesntGetReplaced("Matcap Texture", 2D) = "white" {}
 		[HideInInspector]_MatcapColorTintHolyMolyDontReadThis("Color", Color) = (0,0,0,1)
 	}
@@ -15,7 +15,7 @@
 			CGPROGRAM
 			#pragma vertex vert
 			#pragma fragment frag
-			
+
 			#include "AutoLight.cginc"
 			#include "Lighting.cginc"
 			#include "UnityCG.cginc"
@@ -66,7 +66,7 @@
 
 				return o;
 			}
-			
+
 			fixed4 frag (v2f i) : SV_Target
 			{
 				i.normal = normalize(i.normal);

--- a/XSFallbackTester/Resources/FallbackShaders/Fallback_Unlit.shader
+++ b/XSFallbackTester/Resources/FallbackShaders/Fallback_Unlit.shader
@@ -1,4 +1,4 @@
-﻿Shader "Fallback/Fallback_Unlit"
+﻿Shader "Fallback/Unlit"
 {
 	Properties
 	{
@@ -16,7 +16,7 @@
 			#pragma fragment frag
 			// make fog work
 			#pragma multi_compile_fog
-			
+
 			#include "UnityCG.cginc"
 
 			struct appdata
@@ -34,7 +34,7 @@
 
 			sampler2D _MainTex;
 			float4 _MainTex_ST;
-			
+
 			v2f vert (appdata v)
 			{
 				v2f o;
@@ -43,7 +43,7 @@
 				UNITY_TRANSFER_FOG(o,o.vertex);
 				return o;
 			}
-			
+
 			fixed4 frag (v2f i) : SV_Target
 			{
 				// sample the texture


### PR DESCRIPTION
Code was looking for Fallback/Unlit, but the shader name was Fallback/Fallback_Unlit, same for matcap.